### PR TITLE
Updates for latest sfptpd on puppet7, EL9

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,6 +13,7 @@ class sfptpd::config (
   Optional[Integer] $local_sync_threshold        = $sfptpd::local_sync_threshold,
   String $clock_control                          = $sfptpd::clock_control,
   Optional[String] $clock_list                   = $sfptpd::clock_list,
+  Optional[String] $epoch_guard                  = $sfptpd::epoch_guard,
   Optional[String] $persistent_clock_correction  = $sfptpd::persistent_clock_correction,
   Optional[String] $timestamping_interfaces      = $sfptpd::timestamping_interfaces,
   String $timestamping_disable_on_exit           = $sfptpd::timestamping_disable_on_exit,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,16 +7,19 @@ class sfptpd::params {
   $stats_log                    = undef
   $json_remote_monitor          = undef
   $json_stats                   = undef
-  # Daemon mode conflicts with systemd, so don't enable the daemon option on EL8.
-  $daemon = $facts['os']['release']['major'] ? {
-    '8'     => false,
-    default => true
+  # Daemon mode conflicts with systemd, so don't enable the daemon option on EL8 and above.
+  if Integer($facts['os']['release']['major']) >= 8 {
+    $daemon = false
+  }
+  else {
+    $daemon = true
   }
   $lock                         = 'on'
   $sync_interval                = undef
   $local_sync_threshold         = undef
   $clock_control                = 'slew-and-step'
   $clock_list                   = undef
+  $epoch_guard                  = 'prevent-sync'
   $persistent_clock_correction  = 'on'
   $timestamping_interfaces      = undef
   $timestamping_disable_on_exit = 'on'

--- a/manifests/sync_module/freerun.pp
+++ b/manifests/sync_module/freerun.pp
@@ -1,8 +1,8 @@
+# sfptpd::sync_module::freerun
 define sfptpd::sync_module::freerun(
-  $interface,
-  $priority  = undef,
+  String $interface,
+  Optional[Integer] $priority  = undef,
 ) {
-  validate_string($interface)
 
   concat::fragment { "freerun_${name}":
     target  => $::sfptpd::config_file,

--- a/manifests/sync_module/ntp.pp
+++ b/manifests/sync_module/ntp.pp
@@ -1,11 +1,10 @@
+# sfptpd::sync_module::ntp
 define sfptpd::sync_module::ntp (
-  $ntp_key,
-  $priority          = undef,
-  $sync_threshold    = undef,
-  $ntp_poll_interval = 1,
+  Pattern[/^\d+\s+\S+/] $ntp_key,
+  Optional[Integer] $priority       = undef,
+  Optional[Integer] $sync_threshold = undef,
+  Integer $ntp_poll_interval        = 1,
 ) {
-  validate_re($ntp_key, '^\d+\s+\S+')
-  validate_integer($ntp_poll_interval)
 
   concat::fragment { "ntp_${name}":
     target  => $sfptpd::config_file,

--- a/manifests/sync_module/pps.pp
+++ b/manifests/sync_module/pps.pp
@@ -1,27 +1,19 @@
+# sfptpd::sync_module::pps
 define sfptpd::sync_module::pps(
-  $interface,
-  $priority                = undef,
-  $sync_threshold          = undef,
-  $master_clock_class      = 'locked',
-  $master_time_source      = 'gps',
-  $master_accuracy         = 'unknown',
-  $pps_delay               = undef,
-  $pid_filter_p            = '0.05',
-  $pid_filter_i            = '0.001',
-  $outlier_filter_type     = 'std-dev',
-  $outlier_filter_size     = undef,
-  $outlier_filter_adaption = '1.0',
-  $fir_filter_size         = 4,
+  String $interface,
+  Optional[Integer] $priority                                           = undef,
+  Optional[Integer] $sync_threshold                                     = undef,
+  Enum['locked', 'holdover'] $master_clock_class                        = 'locked',
+  Enum['atomic', 'gps', 'ptp', 'ntp', 'oscillator'] $master_time_source = 'gps',
+  Variant[Integer[0], Enum['unknown']] $master_accuracy                 = 'unknown',
+  Optional[Integer] $pps_delay                                          = undef,
+  Float $pid_filter_p                                                   = 0.05,
+  Float $pid_filter_i                                                   = 0.001,
+  Enum['disabled', 'std-dev'] $outlier_filter_type                      = 'std-dev',
+  Optional[Integer] $outlier_filter_size                                = undef,
+  Float $outlier_filter_adaption                                        = 1.0,
+  Integer $fir_filter_size                                              = 4,
 ) {
-  validate_string($interface)
-  validate_re($master_clock_class, [ '^locked$', '^holdover$' ],
-    "Parameter 'master_clock_class' must be either 'locked' or 'holdover'")
-  validate_re($master_time_source, [ '^atomic$', '^gps$', '^ptp$', '^ntp$', '^oscillator$', ],
-    "Paramter 'master_time_source' must be one of 'atomic', 'gps', 'ptp', 'ntp' or 'oscillator'")
-  validate_re($master_accuracy, [ '^\d+', 'unknown' ],
-    "Parameter 'master_accuracy' must be either a number or 'unknown'")
-  validate_re($outlier_filter_type, [ '^disabled$', '^std-dev$' ],
-    "Parameter 'outlier_filter_type' must be either 'disabled' or 'std-dev'")
 
   concat::fragment { "pps_${name}":
     target  => $::sfptpd::config_file,

--- a/manifests/sync_module/ptp.pp
+++ b/manifests/sync_module/ptp.pp
@@ -1,61 +1,44 @@
+# sfptpd::sync_module::ptp
 define sfptpd::sync_module::ptp(
-  $interface,
-  $ptp_mode                  = 'slave',
-  $priority                  = undef,
-  $sync_threshold            = undef,
-  $ptp_pkt_dump              = false,
-  $ptp_pps_log               = false,
-  $ptp_tx_latency            = undef,
-  $ptp_rx_latency            = undef,
-  $ptp_delay_mechanism       = 'end-to-end',
-  $ptp_network_mode          = 'hybrid',
-  $ptp_ttl                   = 64,
-  $ptp_utc_valid_handling    = undef,
-  $ptp_domain                = 0,
-  $ptp_timing_acl_allow      = undef,
-  $ptp_timing_acl_deny       = undef,
-  $ptp_timing_acl_order      = undef,
-  $ptp_mgmt_acl_allow        = undef,
-  $ptp_mgmt_acl_deny         = undef,
-  $ptp_mgmt_acl_order        = undef,
-  $ptp_announce_interval     = 1,
-  $ptp_announce_timeout      = 6,
-  $ptp_delayreq_interval     = undef,
-  $ptp_delayresp_timeout     = -2,
-  $ptp_bmc_priority1         = undef,
-  $ptp_bmc_priority2         = undef,
-  $ptp_trace                 = 0,
-  $pid_filter_p              = '0.2',
-  $pid_filter_i              = '0.003',
-  $remote_monitor            = undef,
-  $json_remote_monitor       = undef,
-  $mon_monitor_address       = undef,
-  $mon_rx_sync_timing_data   = undef,
-  $mon_rx_sync_computed_data = undef,
-  $outlier_filter_size       = 60,
-  $outlier_filter_adaption   = 1,
-  $mpd_filter_size           = 8,
-  $mpd_filter_ageing         = undef,
-  $fir_filter_size           = 1,
+  String $interface,
+  Enum['slave', 'master'] $ptp_mode                                                            = 'slave',
+  Optional[Integer] $priority                                                                  = undef,
+  Optional[Integer] $sync_threshold                                                            = undef,
+  Boolean $ptp_pkt_dump                                                                        = false,
+  Boolean $ptp_pps_log                                                                         = false,
+  Optional[Integer] $ptp_tx_latency                                                            = undef,
+  Optional[Integer] $ptp_rx_latency                                                            = undef,
+  Enum['end-to-end', 'peer‐to‐peer'] $ptp_delay_mechanism                                      = 'end-to-end',
+  Enum['hybrid', 'multicast'] $ptp_network_mode                                                = 'hybrid',
+  Integer $ptp_ttl                                                                             = 64,
+  Optional[Enum['default', 'ignore', 'prefer', 'require', 'override']] $ptp_utc_valid_handling = undef,
+  Integer $ptp_domain                                                                          = 0,
+  Optional[String] $ptp_timing_acl_allow                                                       = undef,
+  Optional[String] $ptp_timing_acl_deny                                                        = undef,
+  Optional[String] $ptp_timing_acl_order                                                       = undef,
+  Optional[String] $ptp_mgmt_acl_allow                                                         = undef,
+  Optional[String] $ptp_mgmt_acl_deny                                                          = undef,
+  Optional[String] $ptp_mgmt_acl_order                                                         = undef,
+  Integer $ptp_announce_interval                                                               = 1,
+  Integer $ptp_announce_timeout                                                                = 6,
+  Optional[Integer]   $ptp_delayreq_interval                                                   = undef,
+  Integer $ptp_delayresp_timeout                                                               = -2,
+  Optional[Integer] $ptp_bmc_priority1                                                         = undef,
+  Optional[Integer] $ptp_bmc_priority2                                                         = undef,
+  Integer $ptp_trace                                                                           = 0,
+  Float $pid_filter_p                                                                          = 0.2,
+  Float $pid_filter_i                                                                          = 0.003,
+  Optional[String] $remote_monitor                                                             = undef,
+  Optional[String] $json_remote_monitor                                                        = undef,
+  Optional[Stdlib::IP::Address] $mon_monitor_address                                           = undef,
+  Optional[String] $mon_rx_sync_timing_data                                                    = undef,
+  Optional[String] $mon_rx_sync_computed_data                                                  = undef,
+  Integer $outlier_filter_size                                                                 = 60,
+  Integer $outlier_filter_adaption                                                             = 1,
+  Integer $mpd_filter_size                                                                     = 8,
+  Optional[Integer] $mpd_filter_ageing                                                         = undef,
+  Integer $fir_filter_size                                                                     = 1,
 ) {
-  validate_string($interface)
-  validate_re($ptp_mode, [ '^slave$', '^master$'],
-    "Parameter 'ptp_mode' must be either 'slave' or 'master'")
-  validate_bool($ptp_pkt_dump)
-  validate_bool($ptp_pps_log)
-  validate_re($ptp_delay_mechanism, [ '^end-to-end$', '^peer‐to‐peer$' ],
-    "Parameter 'ptp_delay_mechanism' must be either 'end-to-end' or 'peer‐to‐peer'")
-  validate_re($ptp_network_mode, [ '^hybrid$', '^multicast$' ],
-    "Parameter 'ptp_network_mode' must be either 'hybrid' or 'multicast'")
-  validate_integer($ptp_ttl)
-  validate_integer($ptp_domain)
-  validate_integer($ptp_announce_interval)
-  validate_integer($ptp_announce_timeout)
-  validate_integer($ptp_trace)
-  validate_integer($outlier_filter_size)
-  validate_integer($outlier_filter_adaption)
-  validate_integer($mpd_filter_size)
-  validate_integer($fir_filter_size)
 
   concat::fragment { "ptp_${name}":
     target  => $::sfptpd::config_file,

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,8 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "8"
+        "8",
+        "9"
       ]
     }
   ],

--- a/spec/acceptance/sfptpd_config.rb
+++ b/spec/acceptance/sfptpd_config.rb
@@ -14,10 +14,12 @@ describe 'sfptpd::config class' do
     end
     describe file('/etc/sfptpd.conf') do
       it { is_expected.to be_file }
-      its(:content) { is_expected.to match(%r{^sync_mode freerun$}) }
-      its(:content) { is_expected.to match(%r{^freerun_mode nic$}) }
-      its(:content) { is_expected.to match(%r{^ntp_mode off$}) }
-      its(:content) { is_expected.to match(%r{^ntp_poll_interval 1$}) }
+      its(:content) do
+        is_expected.to match(%r{^sync_mode freerun$})
+        is_expected.to match(%r{^freerun_mode nic$})
+        is_expected.to match(%r{^ntp_mode off$})
+        is_expected.to match(%r{^ntp_poll_interval 1$})
+      end
     end
   end
 end

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,1 +1,1 @@
-at_exit { RSpec::Puppet::Coverage.report!  }
+at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,38 +1,34 @@
 require 'beaker-rspec'
 require 'pry'
-test_name "spec_helper_acceptance"
+test_name 'spec_helper_acceptance'
 
-UNSUPPORTED_PLATFORMS = [ 'Windows', 'Solaris', 'AIX'  ]
+UNSUPPORTED_PLATFORMS = [ 'Windows', 'Solaris', 'AIX' ].freeze
 
 config = {
   'main' => {
-    #'storeconfigs' => 'true',
+    # 'storeconfigs' => 'true',
   }
 }
-
 
 unless ENV['BEAKER_provision'] == 'no'
   hosts.each do |host|
     step "Installing puppet on \'#{host}\'"
     # Install Puppet
     install_puppet_on(host, {
-      :version          => '3.8.1',
-    })
+                        version: '3.8.1',
+                      })
     configure_puppet_on(host, config)
     pv = host.execute('puppet --version')
     step "Puppet Version: \'#{pv}\'"
 
-
     # Required for binding tests.
-    if fact('osfamily') == 'RedHat'
-      version = fact("operatingsystemmajrelease")
-      host.execute("yum localinstall -y http://yum.puppetlabs.com/puppetlabs-release-el-#{version}.noarch.rpm")
-      host.execute("yum install -y tar git vim")
-      if fact('operatingsystemmajrelease') =~ /7/ || fact('operatingsystem') =~ /Fedora/
-        host.execute("yum install -y bzip2")
-      end
+    next unless fact('osfamily') == 'RedHat'
+    version = fact('operatingsystemmajrelease')
+    host.execute("yum localinstall -y http://yum.puppetlabs.com/puppetlabs-release-el-#{version}.noarch.rpm")
+    host.execute('yum install -y tar git vim')
+    if fact('operatingsystemmajrelease').include?('7') || fact('operatingsystem').include?('Fedora')
+      host.execute('yum install -y bzip2')
     end
-
   end
 end
 
@@ -42,36 +38,35 @@ RSpec.configure do |c|
   c.formatter = :documentation
 
   # Enable disabling of tests
-  c.filter_run_excluding :broken => true
+  c.filter_run_excluding broken: true
 
   c.before :suite do
-
     # install modules from forge
     forge_modules = [
     ]
     forge_modules.each do |m|
       hosts.each do |host|
         step "Installing puppet module \'#{m}\' on \'#{host}\'"
-        on host, puppet('module','install',m), :acceptable_exit_codes => [0,1]
+        on host, puppet('module', 'install', m), acceptable_exit_codes: [0, 1]
       end
     end
 
     # install modules from git
-    #TODO: work out how to do branches and tags
+    # TODO: work out how to do branches and tags
     git_repos = [
-      { :mod => 'stdlib', :repo => 'https://github.com/puppetlabs/puppetlabs-stdlib.git', },
-      { :mod => 'logrotate', :repo => 'https://github.com/rodjek/puppet-logrotate.git' },
+      { mod: 'stdlib', repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git', },
+      { mod: 'logrotate', repo: 'https://github.com/rodjek/puppet-logrotate.git' },
     ]
     git_repos.each do |g|
       hosts.each do |host|
         step "Installing puppet module \'#{g[:repo]}\' from git on \'#{host}\'"
         on host, "rm -Rf #{default['puppetpath']}/modules/#{g[:mod]}"
-        on host, "git clone #{g[:repo]} #{default['puppetpath']}/modules/#{g[:mod]}", :acceptable_exit_codes => [0,1]
+        on host, "git clone #{g[:repo]} #{default['puppetpath']}/modules/#{g[:mod]}", acceptable_exit_codes: [0, 1]
       end
     end
 
     # Install module
     step "Installing module from \'#{module_root}\'"
-    puppet_module_install(:source => module_root, :module_name => 'sfptpd')
+    puppet_module_install(source: module_root, module_name: 'sfptpd')
   end
 end

--- a/templates/sfptpd.conf.erb
+++ b/templates/sfptpd.conf.erb
@@ -1,4 +1,5 @@
 # Puppet Managed configuration for sfptpd
+[general]
 <% @sync_module.each do |k,v| -%>
 sync_module <%= k %> <% v.each do |n| -%><%= n %> <% end %>
 <% end -%>
@@ -34,6 +35,9 @@ local_sync_threshold <%= @local_sync_threshold %>
 clock_control <%= @clock_control %>
 <% if @clock_list -%>
 clock_list <%= @clock_list %>
+<% end -%>
+<% if @epoch_guard -%>
+epoch_guard <%= @epoch_guard %>
 <% end -%>
 persistent_clock_correction <%= @persistent_clock_correction %>
 <% if @timestamping_interfaces -%>


### PR DESCRIPTION
* add support for `epoch_guard` in configuration
* rubocop corrections
* puppet 7 replace validate functions with data types
* sfptpd-3-6-0 requires a top [general] section
* disable daemon mode EL major >= 8
* support EL9 in metadata.json